### PR TITLE
Pin orjson to 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Topic :: Software Development :: Libraries',
 ]
-requires = ['orjson']
+requires = ['orjson>=2.0.11,<3']
 description-file = 'README.md'
 requires-python = '>=3.8'
 


### PR DESCRIPTION
2.0.11 has a manylinux1 wheel for python3.8, and 3 will be a breaking change for this library due to https://github.com/ijl/orjson/issues/32.