### PR TITLE
Improve to support schema with dynamic properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### UNRELEASED
+
+ - Improve to support schema with dynamic properties
+
+
 ### 0.13.5 - 2020-11-07
 
  - Fix jsonschema_asdataclass function

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### UNRELEASED
+
+ - Improve to support schema with dynamic properties
+
 ### 0.13.5 - 2020-11-07
 
  - Fix jsonschema_asdataclass function


### PR DESCRIPTION
Hello  @dutradda  add the possibility to create _properties dynamically_, I know that it is not very common in shemas, but it is possible due to the documentation of [json-schema.org](https://json-schema.org/understanding-json-schema/reference/object.html ).  and useful in certain cases.

Ex:
```json
{
  "type": "object",
  "required": ["id"],
  "properties": {
    "id": {"type": "string"},
    "title": {"type": "string"},
    "medias": {"type": "array", "items": {"type": "string"}},
    "variations": {
      "type": "object",
      "additionalProperties": {
        "type": "array",
        "items": {"type": "string"}
      },
      "properties": {}
    }
  }
}
```

Any questions we are here :smiley: 